### PR TITLE
support Multi-core debugging.

### DIFF
--- a/tcl/target/renesas_rcar_gen3.cfg
+++ b/tcl/target/renesas_rcar_gen3.cfg
@@ -168,3 +168,23 @@ if { [string equal $_boot_core CA57] } {
 }
 
 eval "target smp $smp_targets"
+
+proc core_state {} {
+	foreach core [target names] {
+		echo "$core : [$core curstate]"
+	}
+}
+
+# Allow access to all cores that skipped examination at initialization.
+proc core_up {} {
+	foreach core [target names] {
+		if {[string equal [$core curstate] "examine deferred"]} {
+			catch { $core arp_examine }
+		}
+	}
+	halt
+}
+
+set _TARGETNAME [lindex [target names] 0]
+$_TARGETNAME configure -event gdb-attach { core_up }
+$_TARGETNAME configure -event gdb-detach { resume }


### PR DESCRIPTION
At boot time, only the boot-core is examined.
In this state, even if other cores are enabled, other cores cannot be halted.
So, allow examine of all cores when GDB attach.