### PR TITLE
output download speed when download finished

### DIFF
--- a/src/flash/nor/tcl.c
+++ b/src/flash/nor/tcl.c
@@ -466,6 +466,13 @@ COMMAND_HANDLER(handle_flash_write_image_command)
 		command_print(CMD, "wrote %" PRIu32 " bytes from file %s "
 			"in %fs (%0.3f KiB/s)", written, CMD_ARGV[0],
 			duration_elapsed(&bench), duration_kbps(&bench, written));
+		LOG_USER(
+			"wrote %" PRIu32 " bytes from file %s "
+	"in %fs (%0.3f KiB/s)",
+			written,
+			CMD_ARGV[0],
+			duration_elapsed(&bench),
+			duration_kbps(&bench, written));
 	}
 
 	image_close(&image);


### PR DESCRIPTION
Hi developer:
i want to openocd output  download speed when download finished like openocd embed in SW4STM32 or STM32cubeIDE, so i create this pull request.
after add this line, it will output like below:

** Programming Started **
Info : device id = 0x10016449
Info : flash size = 1024 kbytes
target halted due to breakpoint, current mode: Thread
xPSR: 0x61000000 pc: 0x20000044 msp: 0x20050000
**_wrote 524288 bytes from file D:/Workspace/STM32CubeMX/Disco-F746NG/cmake-build-d
ebug/Disco-F746NG.elf in 8.681247s (58.978 KiB/s)_**
** Programming Finished **

